### PR TITLE
Add license, gitignore and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# Environments
+.env
+.venv
+
+# MacOS and system files
+.DS_Store
+
+# VSCode settings
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 J. Miguel Vega Martinez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Machine Learning Experiments
+
+This repository contains notebooks and datasets used for experimenting with clustering methods.
+
+## License
+
+The contents of this repository are released under the terms of the [MIT License](LICENSE).
+
+## Development
+
+Common temporary files such as Python caches and Jupyter Notebook checkpoints are excluded from version control via [.gitignore](.gitignore).


### PR DESCRIPTION
## Summary
- add MIT license
- add .gitignore for Python/Notebook cruft
- document license and gitignore in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68892ab9c398832e8a35ac85645e72f3